### PR TITLE
Add support for APFS and Sierra's HFS

### DIFF
--- a/afsctool.c
+++ b/afsctool.c
@@ -92,7 +92,7 @@ bool fileIsCompressable(const char *inFile, struct stat *inFileInfo)
 //			ret >= 0 && fsInfo.f_type == 17
 //				&& S_ISREG(inFileInfo->st_mode)
 //				&& (inFileInfo->st_flags & UF_COMPRESSED) == 0 );
-	return (ret >= 0 && fsInfo.f_type == 17
+	return (ret >= 0 && (fsInfo.f_type == 17 || fsInfo.f_type == 23 || fsInfo.f_type == 29)
 		&& S_ISREG(inFileInfo->st_mode)
 		&& (inFileInfo->st_flags & UF_COMPRESSED) == 0);
 }

--- a/afsctool.c
+++ b/afsctool.c
@@ -92,7 +92,7 @@ bool fileIsCompressable(const char *inFile, struct stat *inFileInfo)
 //			ret >= 0 && fsInfo.f_type == 17
 //				&& S_ISREG(inFileInfo->st_mode)
 //				&& (inFileInfo->st_flags & UF_COMPRESSED) == 0 );
-	return (ret >= 0 && (fsInfo.f_type == 17 || fsInfo.f_type == 23 || fsInfo.f_type == 29)
+	return (ret >= 0 && (!strcasecmp("hfs", fsInfo.f_fstypename) || !strcasecmp("apfs", fsInfo.f_fstypename))
 		&& S_ISREG(inFileInfo->st_mode)
 		&& (inFileInfo->st_flags & UF_COMPRESSED) == 0);
 }


### PR DESCRIPTION
Sierra changes HFS' fs_type_num to 23 (as mentioned here: https://github.com/jrk/afsctool/pull/3), and APFS, which seems to support compression using the same API, uses fs_type_num 29.
This expands the check in fileIsCompressable to accept all three fs_type_num possibilities.

Tested using HFS and APFS disk images on macOS 10.12.4.

This is my first pull request...please be gentle :)