### PR TITLE
Adds CI compilation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+# @see: https://docs.travis-ci.com/
+os: osx
+install:
+- brew install google-sparsehash
+script:
+- cmake .
+- make


### PR DESCRIPTION
See build: [#364353891](https://travis-ci.org/kenorb-contrib/afsctool/builds/364353891).

After merge, Travis CI needs to be enabled at https://travis-ci.org/.