### PR TITLE
Fix version string

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 
-project(afsctool VERSION 1.7.0.14)
+project(afsctool VERSION 1.7.2)
 set(afsctool_FULL_VERSION "${afsctool_VERSION_MAJOR}.${afsctool_VERSION_MINOR}.${afsctool_VERSION_PATCH}.${afsctool_VERSION_TWEAK}")
 
 include(CheckTypeSize)

--- a/History.md
+++ b/History.md
@@ -1,0 +1,21 @@
+1.7.2 / 2022-01-07
+==================
+
+  * Merge branch 'lzfse' (1.7.0-16-gc24bbd5)
+  * Fix a number of warnings
+  * Use -m64 for selecting a 64 bit build on Mac too
+  * Use -m64 for selecting a 64 bit build on Mac too
+  * Use our own lzfse.h !
+  * handle an un-initialised submodule gracefully
+  * Fix the travis CI script and update the checkout instruction
+  * drop the dependency on LZVN and include libLZFSE
+  * PR #39
+  * hopefully fix build issues on Apple's new cpu arch, take 2
+  * hopefully fix build issues on Apple's new cpu arch.
+  * Fix and simplify the LZVN chunking overlap warning
+  * A compression confirmation that should not be shown (because non-verbose) mode has been shown as a compression failure for some time now.
+  * silence some more warnings
+  * Fix CMake file on Mac
+  * explicitify 32 vs 64 bits
+  * Fix build warnings
+  * Don't include MacTypes.h directly but via CoreServices.h instead.


### PR DESCRIPTION
The fix itself is trivial, but commit 4048012 has already been tagged release 1.7.2. Fortunately, it was released merely a few hours ago. Perhaps you can just force retag and force push?
