### PR TITLE
Make lzvn/lzfse slightly smaller

### DIFF
--- a/src/afsctool.c
+++ b/src/afsctool.c
@@ -617,7 +617,8 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			// for this compressor we will let the outBuf grow incrementally. Slower,
 			// but use only as much memory as required.
 
-                        // The chunk table stores the offset of every block, and the offset of where a next block _would_ go
+			// The chunk table stores the offset of every block, and the offset of where a next block _would_ go,
+			// so we need numBlocks + 1 items
 			outBuf = calloc(numBlocks + 1, sizeof(*chunkTable));
 			chunkTable = outBuf;
 			if (!lz_WorkSpace || !chunkTable) {
@@ -641,8 +642,8 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			// for this compressor we will let the outBuf grow incrementally. Slower,
 			// but use only as much memory as required.
 
-                        // The chunk table stores the offset of every block, and the offset of where a next block _would_ go,
-                        // so we need numBlocks + 1 items
+			// The chunk table stores the offset of every block, and the offset of where a next block _would_ go,
+			// so we need numBlocks + 1 items
 			outBuf = calloc(numBlocks + 1, sizeof(*chunkTable));
 			chunkTable = outBuf;
 			if ((!lz_WorkSpace && lz_EstimatedCompressedSize) || !chunkTable) {

--- a/src/afsctool.c
+++ b/src/afsctool.c
@@ -616,7 +616,7 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			lz_WorkSpace = malloc(cmpedsize);
 			// for this compressor we will let the outBuf grow incrementally. Slower,
 			// but use only as much memory as required.
-			outBuf = calloc(numBlocks, sizeof(chunkTable));
+			outBuf = calloc(numBlocks, sizeof(*chunkTable));
 			chunkTable = outBuf;
 			if (!lz_WorkSpace || !chunkTable) {
 				fprintf(stderr,
@@ -627,7 +627,7 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			}
 			struct compressionType t = {CMP_LZVN_XATTR, CMP_LZVN_RESOURCE_FORK};
 			compressionType = t;
-			outBufSize = chunkTableByteSize = numBlocks * sizeof(chunkTable);
+			outBufSize = chunkTableByteSize = numBlocks * sizeof(*chunkTable);
 			chunkTable[0] = chunkTableByteSize;
 			break;
 		}
@@ -638,7 +638,7 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			lz_WorkSpace = lz_EstimatedCompressedSize ? malloc(lz_EstimatedCompressedSize) : 0;
 			// for this compressor we will let the outBuf grow incrementally. Slower,
 			// but use only as much memory as required.
-			outBuf = calloc(numBlocks, sizeof(chunkTable));
+			outBuf = calloc(numBlocks, sizeof(*chunkTable));
 			chunkTable = outBuf;
 			if ((!lz_WorkSpace && lz_EstimatedCompressedSize) || !chunkTable) {
 				fprintf(stderr,
@@ -649,7 +649,7 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			}
 			struct compressionType t = {CMP_LZFSE_XATTR, CMP_LZFSE_RESOURCE_FORK};
 			compressionType = t;
-			outBufSize = chunkTableByteSize = numBlocks * sizeof(chunkTable);
+			outBufSize = chunkTableByteSize = numBlocks * sizeof(*chunkTable);
 			chunkTable[0] = chunkTableByteSize;
 			break;
 #endif

--- a/src/afsctool.c
+++ b/src/afsctool.c
@@ -616,7 +616,9 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			lz_WorkSpace = malloc(cmpedsize);
 			// for this compressor we will let the outBuf grow incrementally. Slower,
 			// but use only as much memory as required.
-			outBuf = calloc(numBlocks, sizeof(*chunkTable));
+
+                        // The chunk table stores the offset of every block, and the offset of where a next block _would_ go
+			outBuf = calloc(numBlocks + 1, sizeof(*chunkTable));
 			chunkTable = outBuf;
 			if (!lz_WorkSpace || !chunkTable) {
 				fprintf(stderr,
@@ -627,7 +629,7 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			}
 			struct compressionType t = {CMP_LZVN_XATTR, CMP_LZVN_RESOURCE_FORK};
 			compressionType = t;
-			outBufSize = chunkTableByteSize = numBlocks * sizeof(*chunkTable);
+			outBufSize = chunkTableByteSize = (numBlocks + 1) * sizeof(*chunkTable);
 			chunkTable[0] = chunkTableByteSize;
 			break;
 		}
@@ -638,7 +640,10 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			lz_WorkSpace = lz_EstimatedCompressedSize ? malloc(lz_EstimatedCompressedSize) : 0;
 			// for this compressor we will let the outBuf grow incrementally. Slower,
 			// but use only as much memory as required.
-			outBuf = calloc(numBlocks, sizeof(*chunkTable));
+
+                        // The chunk table stores the offset of every block, and the offset of where a next block _would_ go,
+                        // so we need numBlocks + 1 items
+			outBuf = calloc(numBlocks + 1, sizeof(*chunkTable));
 			chunkTable = outBuf;
 			if ((!lz_WorkSpace && lz_EstimatedCompressedSize) || !chunkTable) {
 				fprintf(stderr,
@@ -649,7 +654,7 @@ void compressFile(const char *inFile, struct stat *inFileInfo, struct folder_inf
 			}
 			struct compressionType t = {CMP_LZFSE_XATTR, CMP_LZFSE_RESOURCE_FORK};
 			compressionType = t;
-			outBufSize = chunkTableByteSize = numBlocks * sizeof(*chunkTable);
+			outBufSize = chunkTableByteSize = (numBlocks + 1) * sizeof(*chunkTable);
 			chunkTable[0] = chunkTableByteSize;
 			break;
 #endif


### PR DESCRIPTION
The chunk table should have `numBlocks` 32 bit numbers: by using `numBlocks * sizeof(chunktable)` bytes, we were instead making the chunk table 2 times too large on 64 bit machines:

`sizeof(chunkTable)` is `sizeof(pointer)`, but we really only want 4 bytes per item