### PR TITLE
Use https rather than the git protocol for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/private/lzfse"]
 	path = src/private/lzfse
-	url = git://github.com/lzfse/lzfse
+	url = https://github.com/lzfse/lzfse.git


### PR DESCRIPTION
See https://blog.readthedocs.com/github-git-protocol-deprecation/ for info about the deprecation of the git:// protocol on github.

Without this change, it is no longer possible to clone the submodule.